### PR TITLE
chore(vscode): disable preLaunchTask in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
       "type": "node",
       "request": "launch",
       "name": "Debug Server",
-      "preLaunchTask": "tsc-watch",
+      // Launching tasks doesn't work on Windows.
+      // "preLaunchTask": "tsc-watch",
       "port": 9222,
       "restart": true,
       "runtimeExecutable": "npm",
@@ -20,7 +21,8 @@
       "type": "node",
       "request": "attach",
       "name": "Attach to Docker",
-      "preLaunchTask": "tsc-watch",
+      // Launching tasks doesn't work on Windows.
+      // "preLaunchTask": "tsc-watch",
       "port": 9222,
       "restart": true,
       "localRoot": "${workspaceFolder}",


### PR DESCRIPTION
# Changes introduced

This PR disables the `preLaunchTask` configuration key in the launch.json file, since
it doesn't work for whatever reason on Windows. We'll need to revisit this configuration
over time to see if it re-enables itself.

## Related issue(s):

- CSE-269

## Contributor checklist

- [ ] Wrote/updated tests for introduced changes
- [ ] ~~Added new stories for created/modified components (if applicable)~~
- [ ] Updated Postman library for created/modified routes (if applicable)
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [x] Assigned yourself to the PR
- [x] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] ~~Verified that stories were written/modified (if applicable)~~
- [ ] Verified that Postman was updated (if applicable)
- [ ] Checked out the branch and tested changes locally
