### PR TITLE
Configure continuous deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run:
           name: Build image
-          command: 'docker build -t osucass/content-specificication-explorer-api:$TAG_VERSION .'
+          command: 'docker build -t osucass/content-specification-explorer-api:$TAG_VERSION .'
       - run:
           name: Push image to Docker Hub
           command: 'docker push osucass/content-specification-explorer-api:$TAG_VERSION'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ node_defaults: &node
 
 dev_filter: &devOnly
   branches:
-    only: ci/CSE-309-continuous-deployment
+    only: dev
 
 get_latest_version: &getVersion
   name: Set TAG_VERSION and update PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,18 @@ node_defaults: &node
   docker:
     - image: circleci/node
 
+dev_filter: &devOnly
+  branches:
+    only: ci/CSE-309-continuous-deployment
+
+get_latest_version: &getVersion
+  name: Set TAG_VERSION and update PATH
+  command: >
+    echo 'export TAG_VERSION=$((git describe --tags $(git rev-list
+    --tags --max-count=1)) | cut -c 2-)' >> $BASH_ENV
+
+    source $BASH_ENV
+
 version: 2
 jobs:
   build:
@@ -39,6 +51,7 @@ jobs:
           path: reports
       - store_artifacts:
           path: reports/jest
+
   lint:
     <<: *node
     steps:
@@ -49,9 +62,55 @@ jobs:
           name: Run TSLint
           command: npm run lint
 
+  increment_version:
+    <<: *node
+    steps:
+      - checkout
+      - run:
+          name: Run semantic-release
+          command: npx semantic-release
+
+  push_image:
+    machine: true
+    steps:
+      - checkout
+      - run: *getVersion
+      - run:
+          name: Log in to Docker Hub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Build image
+          command: 'docker build -t osucass/content-specificication-explorer-api:$TAG_VERSION .'
+      - run:
+          name: Push image to Docker Hub
+          command: 'docker push osucass/content-specification-explorer-api:$TAG_VERSION'
+
+  deploy:
+    docker:
+      - image: dtzar/helm-kubectl
+    steps:
+      - checkout
+      - run: *getVersion
+      - run:
+          name: Create .kube directory
+          command: mkdir ~/.kube
+      - run:
+          name: Decode kubeconfig
+          command: echo $CSE_KUBE_CONFIG | base64 -d > ~/.kube/config
+      - run:
+          name: Initialize Helm
+          command: helm init --client-only
+      - run:
+          name: Upgrade cluster deployment
+          environment:
+            CHART_VERSION: 0.1.0
+          command: >-
+            helm upgrade --namespace=cse --set-string image.tag=$TAG_VERSION cse
+            https://osu-cass.github.io/AP-CSE-Chart/charts/content-specification-explorer-${CHART_VERSION}.tgz
+
 workflows:
   version: 2
-  build_and_test:
+  build_test_deploy:
     jobs:
       - build
       - unit_tests:
@@ -60,3 +119,15 @@ workflows:
       - lint:
           requires:
             - build
+      - increment_version:
+          filters: *devOnly
+          requires:
+            - unit_tests
+      - push_image:
+          filters: *devOnly
+          requires:
+            - increment_version
+      - deploy:
+          filters: *devOnly
+          requires:
+            - push_image

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     ]
   },
   "release": {
-    "branch": "feat/CSE-309-continuous-deployment",
+    "branch": "ci/CSE-309-continuous-deployment",
     "verifyConditions": "@semantic-release/github",
     "prepare": "",
     "publish": "@semantic-release/github"

--- a/package.json
+++ b/package.json
@@ -118,12 +118,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/osu-cass/AP-CSE-PDF.git"
+    "url": "git+https://github.com/osu-cass/AP-CSE-API.git"
   },
   "author": "",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/osu-cass/AP-CSE-PDF/issues"
+    "url": "https://github.com/osu-cass/AP-CSE-API/issues"
   },
-  "homepage": "https://github.com/osu-cass/AP-CSE-PDF#readme"
+  "homepage": "https://github.com/osu-cass/AP-CSE-API#readme"
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
       "**/*.spec.+(ts)"
     ]
   },
+  "release": {
+    "branch": "feat/CSE-309-continuous-deployment",
+    "verifyConditions": "@semantic-release/github",
+    "prepare": "",
+    "publish": "@semantic-release/github"
+  },
   "dependencies": {
     "body-parser": "^1.18.3",
     "bodybuilder": "^2.2.15",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     ]
   },
   "release": {
-    "branch": "ci/CSE-309-continuous-deployment",
+    "branch": "dev",
     "repositoryUrl": "https://github.com/osu-cass/AP-CSE-API.git",
     "plugins": [
       "@semantic-release/commit-analyzer",

--- a/package.json
+++ b/package.json
@@ -64,9 +64,12 @@
   },
   "release": {
     "branch": "ci/CSE-309-continuous-deployment",
-    "verifyConditions": "@semantic-release/github",
-    "prepare": "",
-    "publish": "@semantic-release/github"
+    "repositoryUrl": "https://github.com/osu-cass/AP-CSE-API.git",
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/github"
+    ]
   },
   "dependencies": {
     "body-parser": "^1.18.3",


### PR DESCRIPTION
# Changes introduced

This PR configures CircleCI to continuously deploy the API to our Kubernetes cluster. It adds the following steps on the `dev` branch:

1. Run `semantic-release` to bump the version number
2. Build and push a Docker image with the new version number to Docker Hub
3. Update the Kubernetes deployment to use the newest Docker image

It also fixes a few issues in the `package.json` from when we copied the project over.

## Related issue(s):

- CSE-308
- CSE-309

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] ~~Added new stories for created/modified components (if applicable)~~
- [ ] Updated Postman library for created/modified routes (if applicable)
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [ ] Removed `WIP:` from the PR title
- [ ] Requested review from the SB Reviewers team

## Reviewer checklist

- [x] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] ~~Verified that stories were written/modified (if applicable)~~
- [ ] Verified that Postman was updated (if applicable)
- [ ] Checked out the branch and tested changes locally
