### PR TITLE
Feat/cse 317 change target endpoint parameters

### DIFF
--- a/cse-api.postman_collection.json
+++ b/cse-api.postman_collection.json
@@ -13,10 +13,10 @@
 					"listen": "test",
 					"script": {
 						"id": "3fb1fb27-9f1a-4417-b724-57371608fd82",
-						"type": "text/javascript",
 						"exec": [
 							""
-						]
+						],
+						"type": "text/javascript"
 					}
 				}
 			],
@@ -31,15 +31,12 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "{{api-domain}}/{{target-endpoint}}/{{subject}}/{{grades}}/{{claim}}/{{target}}",
+					"raw": "{{api-domain}}/{{target-endpoint}}/{{target}}",
 					"host": [
 						"{{api-domain}}"
 					],
 					"path": [
 						"{{target-endpoint}}",
-						"{{subject}}",
-						"{{grades}}",
-						"{{claim}}",
 						"{{target}}"
 					]
 				},
@@ -254,73 +251,73 @@
 	],
 	"variable": [
 		{
-			"id": "7262c459-b8cb-4882-9076-72af04d2e6be",
+			"id": "d304a655-4332-4ab4-9c17-428d6f10cd2f",
 			"key": "api-domain",
 			"value": "http://localhost:3000",
 			"type": "string"
 		},
 		{
-			"id": "bc6b779b-776b-4ff7-8209-fae255db7e49",
+			"id": "13996315-0abf-4e97-b9b4-efdd8a64856d",
 			"key": "pdf-endpoint",
 			"value": "api/pdf",
 			"type": "string"
 		},
 		{
-			"id": "223dd0ff-4274-4eb2-8706-af214340d8aa",
+			"id": "2f18b5d5-9d65-457f-9f33-f3147bd9b95e",
 			"key": "search-endpoint",
 			"value": "api/search",
 			"type": "string"
 		},
 		{
-			"id": "2b2626a2-4d31-4607-8e59-ef0e8dba3595",
+			"id": "d1c29361-0f83-46e3-9882-766e197fea68",
 			"key": "init-endpoint",
 			"value": "api/init",
 			"type": "string"
 		},
 		{
-			"id": "fd7e64ef-4863-42b3-b435-83e3d8317dcb",
+			"id": "2c040783-72ba-4c88-b6f8-41aeafa43e75",
 			"key": "target-endpoint",
 			"value": "api/target",
 			"type": "string"
 		},
 		{
-			"id": "0d9d168c-3ec7-4b75-8e71-09f8df746e70",
+			"id": "151653e7-c368-4996-bff5-d97f34f0525e",
 			"key": "health-endpoint",
 			"value": "health",
 			"type": "string"
 		},
 		{
-			"id": "cb0e115a-e7ac-4f24-a64c-ac86b1a3ee93",
+			"id": "61ea6150-3dc1-485f-b976-a88a4e87d538",
 			"key": "filter-endpoint",
 			"value": "api/filter",
 			"type": "string"
 		},
 		{
-			"id": "251e5c7b-e533-4585-9150-58881910a601",
+			"id": "d74553a7-2919-41c7-9815-87efc7347a04",
 			"key": "subject",
 			"value": "English Language Arts",
 			"type": "string"
 		},
 		{
-			"id": "135011dc-825e-43b8-8cb9-cc53e0d899a3",
+			"id": "6de8fcad-9c7e-4a81-9e07-b91aa5e82ae0",
 			"key": "grades",
 			"value": "3",
 			"type": "string"
 		},
 		{
-			"id": "1124616d-795d-4508-904e-2d41283d94c2",
+			"id": "8e9b0a0c-b704-48e3-a026-6b733ae79cb0",
 			"key": "claim",
-			"value": "C1",
+			"value": "C2",
 			"type": "string"
 		},
 		{
-			"id": "d90dd6c7-f912-47f3-bdfe-37237ca0d16c",
+			"id": "880b06bb-aa20-4907-91de-a23d24cc9202",
 			"key": "target",
 			"value": "E.G3.C2WI.T4",
 			"type": "string"
 		},
 		{
-			"id": "e98879d8-bfbb-4eb3-94ff-e1740195591e",
+			"id": "30374cea-807f-43d2-aece-b7ac7a02fa9f",
 			"key": "query",
 			"value": "simple procedure",
 			"type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6697,9 +6697,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-descriptors": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "jest-junit": "^5.1.0",
     "lint-staged": "^7.2.0",
     "nodemon": "^1.18.3",
+    "merge": ">=1.2.1",
     "prettier": "^1.4.0-beta",
     "ts-jest": "^23.0.1",
     "tslint": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "jest-junit": "^5.1.0",
     "lint-staged": "^7.2.0",
     "nodemon": "^1.18.3",
-    "merge": ">=1.2.1",
     "prettier": "^1.4.0-beta",
     "ts-jest": "^23.0.1",
     "tslint": "^5.11.0",

--- a/src/dal/helpers/index.ts
+++ b/src/dal/helpers/index.ts
@@ -8,26 +8,26 @@ import {
 } from '../../models/filter';
 import { Hash } from '../interface';
 
-function buildSubjectsAndGrades(res: IGradeAndSubjectResult): IFilterOptions {
+function filterSubjects(grades: Hash, grade: string): boolean {
+  if (!grades[grade]) {
+    grades[grade] = grade;
+
+    return true;
+  }
+
+  return false;
+}
+
+export function buildSubjectsAndGrades(res: IGradeAndSubjectResult): IFilterOptions {
   const gradeHash: Hash = {};
   let gradeArr: string[] = [];
   let grades: IFilterItem[] = [];
   let subject: IFilterItem[] = [];
 
   if (res.grades) {
-    // flatten
     res.grades.forEach(g => (gradeArr = gradeArr.concat(g)));
-    // reduce to distinct members
     grades = gradeArr
-      .filter((grade: string) => {
-        if (!gradeHash[grade]) {
-          gradeHash[grade] = grade;
-
-          return true;
-        }
-
-        return false;
-      })
+      .filter((grade: string) => filterSubjects(gradeHash, grade))
       .sort((lhs: string, rhs: string) => parseInt(lhs, 10) - parseInt(rhs, 10))
       .map(g => ({ code: g, label: g }));
   }
@@ -39,24 +39,23 @@ function buildSubjectsAndGrades(res: IGradeAndSubjectResult): IFilterOptions {
   return { subject, grades };
 }
 
-function buildClaimNumbers(dbResult: IClaimNumberResult[]): IFilterOptions {
-  const claimHash: Hash = {};
+function filterClaimNumbers(claimNumbers: Hash, claimNumber: string): boolean {
+  if (!claimNumbers[claimNumber]) {
+    claimNumbers[claimNumber] = claimNumber;
+
+    return true;
+  }
+
+  return false;
+}
+
+export function buildClaimNumbers(dbResult: IClaimNumberResult[]): IFilterOptions {
+  const claimNumbers: Hash = {};
 
   return {
     claimNumbers: dbResult
-      .filter(({ claimNumber }: IClaimNumberResult) => {
-        if (!claimHash[claimNumber]) {
-          claimHash[claimNumber] = claimNumber;
-
-          return true;
-        }
-
-        return false;
-      })
-      .map(({ claimNumber }: IClaimNumberResult) => ({
-        code: claimNumber,
-        label: claimNumber
-      }))
+      .filter(({ claimNumber }: IClaimNumberResult) => filterClaimNumbers(claimNumbers, claimNumber))
+      .map(({ claimNumber }: IClaimNumberResult) => ({code: claimNumber, label: claimNumber}))
   };
 }
 
@@ -67,14 +66,14 @@ function filterShortCodeByGrade(grades: string[], shortCode: string): boolean {
       ? shortCode.includes('HS')
       : shortCode.includes(`G${grade}`);
     if (included) {
-      return included;
+      return true;
     }
   }
 
   return false;
 }
 
-function buildTargetShortCodes(
+export function buildTargetShortCodes(
   grades: string[],
   dbResult: ITargetShortCodeResult[]
 ): IFilterOptions {
@@ -88,4 +87,3 @@ function buildTargetShortCodes(
   };
 }
 
-export { buildSubjectsAndGrades, buildClaimNumbers, buildTargetShortCodes };

--- a/src/dal/helpers/index.ts
+++ b/src/dal/helpers/index.ts
@@ -8,9 +8,9 @@ import {
 } from '../../models/filter';
 import { Hash } from '../interface';
 
-function filterSubjects(grades: Hash, grade: string): boolean {
-  if (!grades[grade]) {
-    grades[grade] = grade;
+function filterValue(hash: Hash, idx: string): boolean {
+  if (!hash[idx]) {
+    hash[idx] = idx;
 
     return true;
   }
@@ -27,7 +27,7 @@ export function buildSubjectsAndGrades(res: IGradeAndSubjectResult): IFilterOpti
   if (res.grades) {
     res.grades.forEach(g => (gradeArr = gradeArr.concat(g)));
     grades = gradeArr
-      .filter((grade: string) => filterSubjects(gradeHash, grade))
+      .filter((grade: string) => filterValue(gradeHash, grade))
       .sort((lhs: string, rhs: string) => parseInt(lhs, 10) - parseInt(rhs, 10))
       .map(g => ({ code: g, label: g }));
   }
@@ -39,22 +39,12 @@ export function buildSubjectsAndGrades(res: IGradeAndSubjectResult): IFilterOpti
   return { subject, grades };
 }
 
-function filterClaimNumbers(claimNumbers: Hash, claimNumber: string): boolean {
-  if (!claimNumbers[claimNumber]) {
-    claimNumbers[claimNumber] = claimNumber;
-
-    return true;
-  }
-
-  return false;
-}
-
 export function buildClaimNumbers(dbResult: IClaimNumberResult[]): IFilterOptions {
   const claimNumbers: Hash = {};
 
   return {
     claimNumbers: dbResult
-      .filter(({ claimNumber }: IClaimNumberResult) => filterClaimNumbers(claimNumbers, claimNumber))
+      .filter(({ claimNumber }: IClaimNumberResult) => filterValue(claimNumbers, claimNumber))
       .map(({ claimNumber }: IClaimNumberResult) => ({code: claimNumber, label: claimNumber}))
   };
 }

--- a/src/dal/interface/index.ts
+++ b/src/dal/interface/index.ts
@@ -1,5 +1,5 @@
 import { MongoClient, Db, Collection, InsertWriteOpResult } from 'mongodb';
-import { ITargetParams } from '../../routes';
+import { ITargetParams, ITargetShortCode } from '../../routes';
 import { IClaim } from '../../models/claim';
 import { Health } from '../../routes/health';
 import * as DbClientHelper from '../helpers';
@@ -35,7 +35,7 @@ export interface IDbClient {
     claimNumber: string
   ): Promise<IFilterOptions | undefined>;
   getClaims(): Promise<IClaim[]>;
-  getTarget(searchParams: ITargetParams): Promise<IClaim>;
+  getTarget(targetShortCode: string): Promise<IClaim>;
 }
 
 /**
@@ -233,18 +233,14 @@ export class DbClient implements IDbClient {
     return result;
   }
 
-  public async getTarget(searchParams: ITargetParams): Promise<IClaim> {
-    const { subject, grades, claimNumber, targetShortCode } = searchParams;
+  public async getTarget(targetShortCode: string): Promise<IClaim> {
     let result: IClaim | undefined;
     if (this.db) {
       try {
         result = (await this.db.collection('claims').findOne({
-          subject,
-          grades,
-          claimNumber,
           'target.shortCode': targetShortCode
         })) as IClaim;
-        result.target = result.target.filter(t => t.shortCode === targetShortCode);
+        // result.target = result.target.filter(t => t.shortCode === targetShortCode);
       } catch (error) {
         throw error;
       }

--- a/src/dal/interface/index.ts
+++ b/src/dal/interface/index.ts
@@ -240,7 +240,6 @@ export class DbClient implements IDbClient {
         result = (await this.db.collection('claims').findOne({
           'target.shortCode': targetShortCode
         })) as IClaim;
-        // result.target = result.target.filter(t => t.shortCode === targetShortCode);
       } catch (error) {
         throw error;
       }

--- a/src/dal/interface/interface-data.spec.ts
+++ b/src/dal/interface/interface-data.spec.ts
@@ -1,6 +1,6 @@
 import { DbClient, IDbClientOptions } from '.';
 import { IClaim } from '../../models/claim';
-import { ITargetParams } from '../../routes';
+import { ITargetParams, ITargetShortCode } from '../../routes';
 import { MongoClient } from 'mongodb';
 
 /*
@@ -162,7 +162,7 @@ describe('MongoDb client interface', () => {
     describe('getTarget', () => {
       let client: DbClient;
       let dbInitArgs: IDbClientOptions;
-      let mockTargetParams: ITargetParams;
+      let mockTargetParams: ITargetShortCode;
 
       beforeAll(() => {
         dbInitArgs = {
@@ -171,9 +171,6 @@ describe('MongoDb client interface', () => {
           dbName: 'test-db'
         };
         mockTargetParams = {
-          subject: 'Math',
-          grades: ['5', '6'],
-          claimNumber: 'C2',
           targetShortCode: '1234'
         };
         client = new DbClient(dbInitArgs);
@@ -181,7 +178,7 @@ describe('MongoDb client interface', () => {
 
       it('gets Target by ITargetParams', async () => {
         await client.connect();
-        const result = await client.getTarget(mockTargetParams);
+        const result = await client.getTarget(mockTargetParams.targetShortCode);
         expect.assertions(1);
         expect(result).toEqual({ target: [{ shortCode: '1234', test: 'passed' }] });
       });
@@ -189,7 +186,7 @@ describe('MongoDb client interface', () => {
       it('throws error getting Target', async () => {
         let result;
         try {
-          result = await client.getTarget(mockTargetParams);
+          result = await client.getTarget(mockTargetParams.targetShortCode);
         } catch (err) {
           expect.assertions(1);
           expect(err).toEqual(new Error('error'));
@@ -200,7 +197,7 @@ describe('MongoDb client interface', () => {
         let result;
         try {
           await client.connect();
-          result = await client.getTarget(mockTargetParams);
+          result = await client.getTarget(mockTargetParams.targetShortCode);
         } catch (err) {
           expect.assertions(1);
           expect(err).toEqual(new Error('db is not defined'));

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,9 @@ import { target } from './target';
 import { search } from './search';
 import { filter } from './filter';
 
+export interface ITargetShortCode {
+  targetShortCode: string;
+}
 export interface ITargetParams {
   subject?: string;
   grades?: string[] | number;
@@ -25,7 +28,7 @@ const router: Router = Router();
 
 router.get('/search/', search);
 router.get('/filter/', filter);
-router.get('/target/:subject/:grades/:claimNumber/:targetShortCode', target);
+router.get('/target/:targetShortCode', target);
 router.post('/init', dbInit);
 
 export { router };

--- a/src/routes/target/index.ts
+++ b/src/routes/target/index.ts
@@ -2,16 +2,16 @@ import { Request } from 'express';
 import { applyTracing } from '../../utils/tracer';
 import { setRouteHealth, Health } from '../health';
 import { CSEResponse, ResponseContext } from '../../server';
-import { ITargetParams } from '..';
+import { ITargetShortCode } from '..';
 
 export const handler = async (req: Request, res: CSEResponse) => {
   const { dbClient }: ResponseContext = res.locals;
-  const { ...params }: ITargetParams = <ITargetParams>req.params;
+  const { targetShortCode }: ITargetShortCode = <ITargetShortCode>req.params;
   let result: object | undefined;
   try {
     setRouteHealth(Health.busy, req);
     await dbClient.connect();
-    result = await dbClient.getTarget(params);
+    result = await dbClient.getTarget(targetShortCode);
     await dbClient.close();
     res.status(200);
   } catch (error) {


### PR DESCRIPTION
# Changes introduced

Changes the `target/` endpoint to take the target short code as a path parameter. Like this,
```
api/target/M.GHS.C2.TA
``` 

## Related issue(s):

- CSE-298
- CSE-317

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] ~~Added new stories for created/modified components (if applicable)~~
- [x] Updated Postman library for created/modified routes (if applicable)
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] ~~Verified that stories were written/modified (if applicable)~~
- [ ] Verified that Postman was updated (if applicable)
- [ ] Checked out the branch and tested changes locally
