### PR TITLE
fix(import-script): improves taskmodel importing functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3254,15 +3254,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3279,22 +3277,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3425,8 +3420,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3440,7 +3434,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3457,7 +3450,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3466,15 +3458,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3495,7 +3485,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3584,8 +3573,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3599,7 +3587,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3737,7 +3724,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/dal/helpers/index.ts
+++ b/src/dal/helpers/index.ts
@@ -119,7 +119,9 @@ export function buildTargetShortCodes(
   dbResult: ITargetShortCodeResult[]
 ): IFilterOptions | undefined {
   const flatResult: IShortCodeResult[] = [];
-  dbResult.forEach((res: ITargetShortCodeResult) => flatResult.push(...res.target));
+  dbResult.forEach((res: ITargetShortCodeResult) => {
+    flatResult.push(...res.target);
+  });
 
   const targetShortCodes: IFilterItem[] = flatResult
     .filter(({ shortCode }: IShortCodeResult) => filterShortCodeByGrade(grades, shortCode))

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -149,12 +149,11 @@ export async function importDbEntries(): Promise<IClaim[]> {
 
 /**
  * Merges split multi-targets into the main IClaim array
- * @export
- * @param {IClaim[]} claimArray
- * @param {IClaim} newClaim
- * @param {ISpecDocument} claim
+ * @param {IClaim[]} claimArray A reference to the Array of either empty or completed claim documents
+ * @param {IClaim} newClaim A reference to the new CSE Claim to be added to the claim array
+ * @param {ISpecDocument} claim A reference to the CSE Claim's corresponding CASE Claim document
  */
-export function pushToClaimArray(claimArray: IClaim[], newClaim: IClaim, claim: ISpecDocument) {
+ function pushToClaimArray(claimArray: IClaim[], newClaim: IClaim, claim: ISpecDocument) {
   let tempClaim: IClaim;
   if (newClaim.target[0].title.includes('Targets ')) {
     const tNum = parseInt(newClaim.target[0].title.split(' Targets ')[1].split('a')[0], 10);
@@ -173,12 +172,11 @@ export function pushToClaimArray(claimArray: IClaim[], newClaim: IClaim, claim: 
 
 /**
  * Translates target information from multi-grade-and-claim documents
- * @export
- * @param {ISpecDocument} claim
- * @param {*} newClaim
- * @param {ISpecDocument} DOKDOC
+ * @param {ISpecDocument} claim A reference to the current CASE Claim Document
+ * @param {*} newClaim  An empty 'Any' type that will become a new Claim
+ * @param {ISpecDocument} DOKDOC A reference to norm_webb_s_depth_of_knowledge__dok__levels_of_cognitive_difficulty
  */
-export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpecDocument) {
+ function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpecDocument) {
   const taskModels: ITaskModel[] = [];
   const titles: string[] = [];
 
@@ -260,11 +258,10 @@ export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpe
 
 /**
  * Extracts the target-specific shortcode from one of a document's items
- * @export
- * @param {ISpecDocument} claim
+ * @param {ISpecDocument} claim A reference to the current CASE claim document
  * @returns {(string | undefined)}
  */
-export function getTargetShortCode(claim: ISpecDocument): string | undefined {
+ function getTargetShortCode(claim: ISpecDocument): string | undefined {
   for (const item of claim.CFItems) {
     if (item.CFItemType === 'Target' && item.humanCodingScheme !== undefined) {
       return item.humanCodingScheme;
@@ -274,13 +271,12 @@ export function getTargetShortCode(claim: ISpecDocument): string | undefined {
 
 /**
  * Extracts the claim shortcode in Subject.Grade.Claim format from a document's title
- * @export
- * @param {string} subject
- * @param {string} claim
- * @param {string[]} grade
+ * @param {string} subject The subject of a given claim @example 'MATH' or 'ELA'
+ * @param {string} claim A String with the Claim number @example 'C1' or 'C4'
+ * @param {string[]} grade An array of one or more grades @example ['08', '09', '10'] or ['03']
  * @returns
  */
-export function getClaimShortCode(subject: string, claim: string, grade: string[]) {
+ export function getClaimShortCode(subject: string, claim: string, grade: string[]) {
   const gradeLevel: string | string[] = parseInt(grade[0], 10) > 8 ? 'HS' : grade;
   if (grade.length > 1) {
     if (parseInt(grade[0], 10) < 9) {
@@ -297,13 +293,12 @@ export function getClaimShortCode(subject: string, claim: string, grade: string[
  * Extracts the claim number from a document's title in CX format (e.g C1, C2, C3)
  * See Data Structure docs for info on the differences between document titles
  * (https://github.com/osu-cass/SB-CSE-Data-Structure)
- * @export
- * @param {string} title
- * @param {string} subject
- * @param {string[]} grades
+ * @param {string} title The title of a claim
+ * @param {string} subject The subject of a given claim @example 'MATH' or 'ELA'
+ * @param {string[]} grades An array of one or more grades @example ['08', '09', '10'] or ['03']
  * @returns
  */
-export function getClaim(title: string, subject: string, grades: string[]) {
+ export function getClaim(title: string, subject: string, grades: string[]) {
   let titlecopy = ` ${title}`.slice(1);
   let titlearray = [];
   if (subject === Subject.ELA) {
@@ -336,8 +331,7 @@ export function getClaim(title: string, subject: string, grades: string[]) {
 
 /**
  * Fetches all the data for each document supplied from fetchAllDocs()
- * @export
- * @param {ISpecDocument[]} arr
+ * @param {ISpecDocument[]} arr A reference to the empty array of documents to be filled
  * @returns {number}
  */
 export async function importDocs(arr: ISpecDocument[]): Promise<number> {
@@ -360,10 +354,9 @@ export async function importDocs(arr: ISpecDocument[]): Promise<number> {
 
 /**
  * Fetches the Identifiers for every document in the CASE DB
- * @export
  * @returns
  */
-export async function fetchAllDocs(): Promise<string[]> {
+ export async function fetchAllDocs(): Promise<string[]> {
   const identifiers: string[] = [];
   const temp = await fetch(
     'https://case.smarterbalanced.org/ims/case/v1p0/CFDocuments?limit=99999999999&offset=0&sort&orderBy&filter&fields'
@@ -378,10 +371,9 @@ export async function fetchAllDocs(): Promise<string[]> {
 
 /**
  * Maps Depth-of-knowledge and standards documents
- * @export
  * @returns {ISpecDocument[]}
  */
-export function specDocs(): ISpecDocument[] {
+ function specDocs(): ISpecDocument[] {
   const specs: ISpecDocument[] = [];
   for (let i = 0; i < docNames.length; i++) {
     if (docNames[i].includes('smarter_balanced_ela_content_specification')) {
@@ -400,12 +392,11 @@ export function specDocs(): ISpecDocument[] {
 
 /**
  *  Extracts target-specific data for a given document
- * @export
- * @param {IClaim} claim
- * @param {ISpecDocument} jsonData
- * @param {ISpecDocument} DOKDOC
+ * @param {IClaim} claim A reference to the in-progress CSE claim document
+ * @param {ISpecDocument} jsonData A reference to the CASE claim document
+ * @param {ISpecDocument} DOKDOC A reference to norm_webb_s_depth_of_knowledge__dok__levels_of_cognitive_difficulty
  */
-export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecDocument): void {
+ function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecDocument): void {
   if (claim.shortCode.includes('M.GHS.C') && !claim.shortCode.includes('C1')) {
     getMultiTarget(jsonData, claim, DOKDOC);
   } else {
@@ -477,11 +468,10 @@ export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecD
 
 /**
  * Builds the Related Evidence for Task Models
- * @export
- * @param {IClaim} claim
- * @param {ISpecDocument} jsonData
+ * @param {IClaim} claim A reference to the in-progress CSE claim document
+ * @param {ISpecDocument} jsonData A reference to the CASE claim document
  */
-export function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument): void {
+ function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument): void {
   const taskAssociations = jsonData.CFAssociations.filter(
     association =>
       association.originNodeURI.title.includes('Task Model ') &&
@@ -500,11 +490,10 @@ export function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument): v
 
 /**
  * Extracts the target properties that are found under the "General Requirements" item types in a given document
- * @export
- * @param {IClaim} claim
- * @param {ISpecDocument} jsonData
+ * @param {IClaim} claim A reference to the in-progress CSE claim document
+ * @param {ISpecDocument} jsonData A reference to the CASE claim document
  */
-export function getGenReqs(claim: IClaim, jsonData: ISpecDocument): void {
+ function getGenReqs(claim: IClaim, jsonData: ISpecDocument): void {
   for (const item of jsonData.CFItems) {
     if (item.CFItemType === 'General Requirements') {
       if (item.abbreviatedStatement === 'Key/Construct Relevant Vocabulary') {
@@ -532,9 +521,9 @@ export function getGenReqs(claim: IClaim, jsonData: ISpecDocument): void {
 /**
  * returns the domain for a given ELA document.
  *
- * @param {string} subject
- * @param {string} shortCode
- * @param {ISpecDocument} ELASpec
+ * @param {string} subject The subject of a given claim @example 'MATH' or 'ELA'
+ * @param {string} shortCode The claim shortcode @example 'E.G3.C1' or 'M.GHS.C2'
+ * @param {ISpecDocument} ELASpec A reference to the smarter_balanced_ELA_content_specification
  * @returns {(string | undefined)}
  */
 function getClaimDomain(shortCode: string, ELASpec: ISpecDocument): string | undefined {
@@ -552,10 +541,10 @@ function getClaimDomain(shortCode: string, ELASpec: ISpecDocument): string | und
 
 /**
  * Finds and returns the description for a given claim
- * @param {string} subject
- * @param {string} shortCode
- * @param {ISpecDocument} ELASpec
- * @param {ISpecDocument} MATHSpec
+ * @param {string} subject The subject of a given claim @example 'MATH' or 'ELA'
+ * @param {string} shortCode The claim shortcode @example 'E.G3.C1' or 'M.GHS.C2'
+ * @param {ISpecDocument} ELASpec A reference to the smarter_balanced_ELA_content_specification
+ * @param {ISpecDocument} MATHSpec A reference to the smarter_balanced_math_content_specification
  * @returns {(String || undefined)}
  */
 function getClaimDesc(
@@ -581,11 +570,10 @@ function getClaimDesc(
 
 /**
  *  Merges all targets that share the same claim number into a singular claim object with an array of targets.
- * @export
- * @param {IClaim[]} claimArray
+ * @param {IClaim[]} claimArray A reference to the Array of Claims
  * @returns {IClaim[]}
  */
-export function consolidate(claimArray: IClaim[]): IClaim[] {
+ function consolidate(claimArray: IClaim[]): IClaim[] {
   let tempArray = [];
   let claimHolder;
   let finalArray: IClaim[] = [];
@@ -640,10 +628,9 @@ export function consolidate(claimArray: IClaim[]): IClaim[] {
 
 /**
  * Special case that splits claim C1 into C1a and C1b claims
- * @export
- * @param {IClaim[]} finalArray
+ * @param {IClaim[]} finalArray A reference to the array of Targets
  */
-export function expandFirstClaim(finalArray: IClaim[]): void {
+ function expandFirstClaim(finalArray: IClaim[]): void {
   const claimArray: IClaim[] = [];
   finalArray.forEach(claim => {
     if (claim.claimNumber === 'C1' && claim.subject === Subject.ELA) {
@@ -669,10 +656,9 @@ export function expandFirstClaim(finalArray: IClaim[]): void {
 
 /**
  * Merges Targets of the type 'Performance Task' into their corresponding grade-and-claims
- * @export
- * @param {IClaim[]} finalArray
+ * @param {IClaim[]} finalArray A reference to the array of Targets
  */
-export function handlePT(finalArray: IClaim[]): void {
+ function handlePT(finalArray: IClaim[]): void {
   let PTArr: IClaim[] = [];
   let idx: number;
 
@@ -694,71 +680,85 @@ export function handlePT(finalArray: IClaim[]): void {
  * @param finalArray
  * @returns {IClaim[]}
  */
-export function removePT(finalArray: IClaim[]): IClaim[] {
+ function removePT(finalArray: IClaim[]): IClaim[] {
   return finalArray.filter(claim => !claim.title.includes('Performance'));
 }
 
 // tslint:disable:no-non-null-assertion
 /**
  * Builds task models from Item Associations
- * @export
- * @param {string} identifier
- * @param {ISpecDocument} jsonData
- * @param {string} name
+ * @param {string} identifier The GUID of a Task Model CFItem
+ * @param {ISpecDocument} jsonData A reference to the document
+ * @param {string} name The Task Model name @example 'Task Model 3'
  * @returns {ITaskModel}
  */
-export function getTaskModel(
+ function getTaskModel(
   identifier: string,
   jsonData: ISpecDocument,
   name: string
 ): ITaskModel {
   const associations = jsonData.CFAssociations.filter(
-    association => association.destinationNodeURI.identifier === identifier
+    a => a.destinationNodeURI.identifier === identifier
   );
-
-  const descriptionId = associations.find(
-    association => association.originNodeURI.title === 'Task Description'
-  )!.originNodeURI.identifier;
-
-  const stimulusId = associations.find(
-    association => association.originNodeURI.title === 'Stimulus'
-  )
-    ? associations.find(association => association.originNodeURI.title === 'Stimulus')!
-        .originNodeURI.identifier
-    : undefined;
-
-  const stemId = associations.find(
-    association => association.originNodeURI.title === 'Appropriate Stems'
-  )
-    ? associations.find(association => association.originNodeURI.title === 'Appropriate Stems')!
-        .originNodeURI.identifier
-    : undefined;
-
-    const exampleArr = associations.filter(association => association.originNodeURI.title === 'Examples');
-    let exampleText: string[] | undefined = [];
-    if(exampleArr.length > 0) {
-    exampleArr.forEach(e =>  {
-      if(jsonData.CFItems.find(item => item.identifier === e.originNodeURI.identifier)) {
-        exampleText!.push(jsonData.CFItems.find(item => item.identifier === e.originNodeURI.identifier)!.fullStatement);
-      }
-    });
+  const descriptionId = getAssocId(associations, 'Task Description', false) as string;
+  const stimulusId = getAssocId(associations, 'Stimulus', true);
+  const stemId = getAssocId(associations, 'Appropriate Stems', true);
+  const exampleArr = associations.filter(association => association.originNodeURI.title === 'Examples');
+  const exampleText: string[] | undefined = [];
+  exampleArr.forEach(e => {
+    if (findAssocItem(jsonData, e.originNodeURI.identifier, false)) {
+      exampleText.push(findAssocItem(jsonData, e.originNodeURI.identifier, false));
     }
-    else {
-      exampleText = undefined;
-    }
+  });
 
   return {
     taskName: name,
-    taskDesc: jsonData.CFItems.find(item => item.identifier === descriptionId)!.fullStatement,
+    taskDesc: findAssocItem(jsonData, descriptionId, false),
     stimulus: stimulusId
-      ? jsonData.CFItems.find(item => item.identifier === stimulusId)!.fullStatement
+      ? findAssocItem(jsonData, stimulusId, false)
       : undefined,
-      examples: exampleText,
+    examples: exampleText,
     stem: stemId
       ? {
-          stemDesc: jsonData.CFItems.find(item => item.identifier === stemId)!.fullStatement,
-          shortStem: jsonData.CFItems.find(item => item.identifier === stemId)!.abbreviatedStatement
-        }
+        stemDesc: findAssocItem(jsonData, stemId, false),
+        shortStem: findAssocItem(jsonData, stemId, true),
+      }
       : undefined
   };
+}
+/**
+ * This function returns the item GUID for a queried association in the document
+ *
+ * @param {ICFAssociation[]} associations An array of ICFAssociation Entries to search through
+ * @param {string} title The association title to query for @example 'Task Description' or 'Stimulus'
+ * @param {boolean} optional True means the variable this function is returning to is of type string | undefined
+ * @returns
+ */
+function getAssocId(associations: ICFAssociation[], title: string, optional: boolean) {
+  if (optional) {
+    return associations.find(association => association.originNodeURI.title === title)
+      ? associations.find(association => association.originNodeURI.title === title)!
+        .originNodeURI.identifier
+      : undefined;
+  }
+
+  return associations.find(
+    association => association.originNodeURI.title === title
+  )!.originNodeURI.identifier;
+}
+
+/**
+ * This function will return the fullstatement/abbreviatedstatement that is tied to a CFItem when supplied with an Item GUID
+ *
+ * @param {ISpecDocument} jsonData A reference to the document
+ * @param {string} id GUID of the item you want to find
+ * @param {boolean} abbreviate True returns the found item's abbreviatedstatement. False returns the fullstatement
+ * @returns
+ */
+function findAssocItem(jsonData: ISpecDocument, id: string, abbreviate: boolean) {
+  if(abbreviate) {
+    return jsonData.CFItems.find(item => item.identifier === id)!.abbreviatedStatement;
+  }
+
+  return jsonData.CFItems.find(item => item.identifier === id)!.fullStatement;
 }

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -10,7 +10,7 @@ enum Subject {
   ELA = 'English Language Arts',
   MATH = 'Math'
 }
-const docs = [
+const docs: string[] = [
   'smarter_balanced_ela_content_specification',
   'air_deprecated_ela_claims_and_targets',
   'air_deprecated_math_claims_and_targets',
@@ -28,164 +28,163 @@ const docArr: ISpecDocument[] = [];
 const docNames: string[] = [];
 // tslint:disable:max-func-body-length
 /**
- * This function migrates CASE API documents into a new data model.
- *
+ * Migrates CASE API documents into a new data model, an array
+ * of IClaim objects.
  * @export
  * @returns {Promise<IClaim[]>}
  */
 export async function importDbEntries(): Promise<IClaim[]> {
   let dokSpec: ISpecDocument;
-  let newClaim: any = {};
+  let claim: any = {};
   const claimArray: IClaim[] = [];
-  const arr: ISpecDocument[] = [];
-  await importDocs(arr);
+  const specifications: ISpecDocument[] = [];
+  await importDocs(specifications);
   const specs = specDocs();
   const ELASpec: ISpecDocument = specs[0];
   const MATHSpec: ISpecDocument = specs[1];
   const DOKDOC: ISpecDocument = specs[2];
 
-  arr.forEach(claim => {
-    newClaim = {};
-    // this line is necessary for one bug in the CASE API
-    if (claim.CFDocument.subject === undefined) {
-      newClaim.subject = Subject.ELA;
+  specifications.forEach(specification => {
+    claim = {};
+    // special case for one bug in the CASE API
+    if (specification.CFDocument.subject === undefined) {
+      claim.subject = Subject.ELA;
     } else {
-      newClaim.subject = claim.CFDocument.subject[0];
+      claim.subject = specification.CFDocument.subject[0];
     }
-    newClaim.title = claim.CFDocument.title;
-    newClaim.grades = [];
-    // this handles high-school multi-grades (e.g: 09, 10, 11, 12)
-    if (claim.CFItems[0].educationLevel.length > 1) {
-      claim.CFItems[0].educationLevel.forEach((edu: string) =>
-        newClaim.grades.push(`${parseInt(edu, 10)}`)
+    claim.title = specification.CFDocument.title;
+    claim.grades = [];
+    // special case for high-school multi-grades (e.g: 09, 10, 11, 12)
+    if (specification.CFItems[0].educationLevel.length > 1) {
+      specification.CFItems[0].educationLevel.forEach((edu: string) =>
+        claim.grades.push(`${parseInt(edu, 10)}`)
       );
     } else {
-      newClaim.grades[0] = `${parseInt(claim.CFItems[0].educationLevel[0], 10)}`;
+      claim.grades[0] = `${parseInt(specification.CFItems[0].educationLevel[0], 10)}`;
     }
-    newClaim.claimNumber = getClaim(newClaim.title, newClaim.subject, newClaim.grades);
-    newClaim.target = [{}];
-    if (newClaim.title.includes('Performance')) {
-      while (newClaim.claimNumber.charAt(0) === 'C') {
-        newClaim.claimNumber = newClaim.claimNumber.substr(1);
+    claim.claimNumber = getClaim(claim.title, claim.subject, claim.grades);
+    claim.target = [{}];
+    if (claim.title.includes('Performance')) {
+      while (claim.claimNumber.charAt(0) === 'C') {
+        claim.claimNumber = claim.claimNumber.substr(1);
       }
-      newClaim.target[0].interactionType = 'PT';
+      claim.target[0].interactionType = 'PT';
     }
-    newClaim.shortCode = getClaimShortCode(newClaim.subject, newClaim.claimNumber, newClaim.grades);
-    if (!newClaim.title.includes('Performance')) {
-      newClaim.description = getClaimDesc(newClaim.subject, newClaim.shortCode, ELASpec, MATHSpec);
-      if (newClaim.subject !== Subject.MATH && !newClaim.title.includes('Performance')) {
-        newClaim.domain = [];
-        newClaim.domain.push({
-          title: getClaimDomain(newClaim.subject, newClaim.shortCode, ELASpec)
+    claim.shortCode = getClaimShortCode(claim.subject, claim.claimNumber, claim.grades);
+    if (!claim.title.includes('Performance')) {
+      claim.description = getClaimDesc(claim.subject, claim.shortCode, ELASpec, MATHSpec);
+      if (claim.subject !== Subject.MATH && !claim.title.includes('Performance')) {
+        claim.domain = [];
+        claim.domain.push({
+          title: getClaimDomain(claim.shortCode, ELASpec)
         });
       }
     }
-    if (newClaim.shortCode.includes('-')) {
-      newClaim.domain = [];
-      for (const item of claim.CFItems) {
+    if (claim.shortCode.includes('-')) {
+      claim.domain = [];
+      for (const item of specification.CFItems) {
         if (
           item.CFItemType === 'Domain' ||
           item.abbreviatedStatement === 'Primary Content Domain' ||
           item.abbreviatedStatement === 'Secondary Content Domain'
         ) {
           if (item.abbreviatedStatement === undefined) {
-            newClaim.domain.push({
+            claim.domain.push({
               title: item.fullStatement
             });
           } else {
-            newClaim.domain.push({
+            claim.domain.push({
               title: item.abbreviatedStatement,
               desc: item.fullStatement
             });
           }
         }
       }
-      getMultiTarget(claim, newClaim, DOKDOC);
+      getMultiTarget(specification, claim, DOKDOC);
     } else {
-      newClaim.target[0].title = claim.CFDocument.title;
-      newClaim.target[0].shortCode = getTargetShortCode(claim);
+      claim.target[0].title = specification.CFDocument.title;
+      claim.target[0].shortCode = getTargetShortCode(specification);
 
-      getTarget(newClaim, claim, DOKDOC);
-      const catPT = claim.CFDocument.creator.split(' ');
-      catPT
-        .filter((p: string) => p.includes('CAT'))
-        .forEach((p: string) => (newClaim.target[0].interactionType = p));
-      if (newClaim.subject === Subject.ELA) {
+      getTarget(claim, specification, DOKDOC);
+      specification.CFDocument.creator.split(' ')
+        .filter((interactionType: string) => interactionType.includes('CAT'))
+        .forEach((interactionType: string) => (claim.target[0].interactionType = interactionType));
+
+      if (claim.subject === Subject.ELA) {
         dokSpec = ELASpec;
       } else {
         dokSpec = MATHSpec;
       }
       let uriString: string[];
-      newClaim.target[0].DOK = [];
+      claim.target[0].DOK = [];
       for (const association of dokSpec.CFAssociations) {
-        if (association.originNodeURI.title.includes(newClaim.target[0].shortCode)) {
+        if (association.originNodeURI.title.includes(claim.target[0].shortCode)) {
           if (association.destinationNodeURI.uri.includes('DOK')) {
             uriString = association.destinationNodeURI.uri.split('DOK:');
             const uri = uriString[1].replace('%20', '');
-            if (newClaim.target[0].DOK.length === 0) {
-              newClaim.target[0].DOK.push({
+            if (claim.target[0].DOK.length === 0) {
+              claim.target[0].DOK.push({
                 dokCode: uri
               });
-            } else if (!newClaim.target[0].DOK.find((d: IDOK) => d.dokCode.includes(uri))) {
-              newClaim.target[0].DOK.push({ dokCode: uri });
+            } else if (!claim.target[0].DOK.find((dok: IDOK) => dok.dokCode.includes(uri))) {
+              claim.target[0].DOK.push({ dokCode: uri });
             }
           }
         }
       }
-      newClaim.target[0].DOK.forEach((d: IDOK) => {
-        for (const q of DOKDOC.CFItems) {
-          if (q.humanCodingScheme === d.dokCode) {
-            d.dokDesc = q.fullStatement;
-            d.dokShort = q.abbreviatedStatement;
+      claim.target[0].DOK.forEach((dok: IDOK) => {
+        for (const item of DOKDOC.CFItems) {
+          if (item.humanCodingScheme === dok.dokCode) {
+            dok.dokDesc = item.fullStatement;
+            dok.dokShort = item.abbreviatedStatement;
           }
         }
       });
     }
-    pushToClaimArray(claimArray, newClaim, claim);
+    pushToClaimArray(claimArray, claim, specification);
   });
 
   return consolidate(claimArray);
 }
 
 /**
- * Handles merging split multi-targets into the main claim array
- *
+ * Merges split multi-targets into the main IClaim array
  * @export
  * @param {IClaim[]} claimArray
  * @param {IClaim} newClaim
  * @param {ISpecDocument} claim
  */
 export function pushToClaimArray(claimArray: IClaim[], newClaim: IClaim, claim: ISpecDocument) {
-  let temp: IClaim;
+  let tempClaim: IClaim;
   if (newClaim.target[0].title.includes('Targets ')) {
     const tNum = parseInt(newClaim.target[0].title.split(' Targets ')[1].split('a')[0], 10);
     const tCode = `${newClaim.target[0].shortCode.split(`T${tNum}a`)[0]}T${tNum}b`;
     const targIdx = claim.CFItems.findIndex(i => i.humanCodingScheme === tCode);
     const endTarg = claim.CFItems[targIdx];
     newClaim.target[0].title = `${newClaim.target[0].title.split(' Targets ')[0]} Target ${tNum}a`;
-    temp = JSON.parse(JSON.stringify(newClaim));
-    temp.target[0].shortCode = endTarg.humanCodingScheme;
-    temp.target[0].description = endTarg.fullStatement;
-    temp.target[0].title = `${temp.target[0].title.split(' Target ')[0]} Target ${tNum}b`;
-    claimArray.push(temp);
+    tempClaim = JSON.parse(JSON.stringify(newClaim));
+    tempClaim.target[0].shortCode = endTarg.humanCodingScheme;
+    tempClaim.target[0].description = endTarg.fullStatement;
+    tempClaim.target[0].title = `${tempClaim.target[0].title.split(' Target ')[0]} Target ${tNum}b`;
+    claimArray.push(tempClaim);
   }
   claimArray.push(newClaim);
 }
 
 /**
- * This function handles target information for multi-grade-and-claim documents
- *
+ * Translates target information from multi-grade-and-claim documents
  * @export
  * @param {ISpecDocument} claim
  * @param {*} newClaim
  * @param {ISpecDocument} DOKDOC
  */
 export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpecDocument) {
-  const tModels: ITaskModel[] = [];
-  const titleArr: string[] = [];
+  const taskModels: ITaskModel[] = [];
+  const titles: string[] = [];
+
   for (const i of claim.CFItems) {
     if (i.CFItemType === 'Target' && i.abbreviatedStatement.includes('Target ')) {
-      titleArr.push(i.abbreviatedStatement);
+      titles.push(i.abbreviatedStatement);
       newClaim.target.push({
         title: `${i.CFDocumentURI.title}, ${i.abbreviatedStatement}`,
         shortCode: i.humanCodingScheme,
@@ -209,7 +208,7 @@ export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpe
           break;
         }
       }
-      tModels.push({
+      taskModels.push({
         taskName: claim.CFItems[i].fullStatement,
         taskDesc: claim.CFItems[i + 1].fullStatement,
         examples: exampleArr
@@ -217,16 +216,16 @@ export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpe
     }
   }
 
-  for (const targ of newClaim.target) {
+  for (const target of newClaim.target) {
     let iter = 0;
-    targ.taskModels = [];
+    target.taskModels = [];
     let tSplit;
-    for (const task of tModels) {
-      if (targ.title !== undefined && !targ.shortCode.includes('M.GHS')) {
-        tSplit = targ.title.split(', ')[2];
+    for (const task of taskModels) {
+      if (target.title !== undefined && !target.shortCode.includes('M.GHS')) {
+        tSplit = target.title.split(', ')[2];
         const code = `${newClaim.claimNumber.slice(1)}${tSplit.replace('Target ', '')}`;
         if (task.taskName.split('.')[0].includes(code)) {
-          targ.taskModels.push({
+          target.taskModels.push({
             taskName: task.taskName,
             taskDesc: task.taskDesc,
             examples: [task.examples]
@@ -234,23 +233,23 @@ export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpe
           iter++;
         }
       } else {
-        targ.taskModels.push(task);
+        target.taskModels.push(task);
       }
     }
   }
 
-  for (const targ of newClaim.target) {
+  for (const target of newClaim.target) {
     for (const association of claim.CFAssociations) {
-      for (const items of DOKDOC.CFItems) {
+      for (const item of DOKDOC.CFItems) {
         if (
-          association.originNodeURI.title === targ.shortCode &&
-          association.destinationNodeURI.identifier === items.identifier
+          association.originNodeURI.title === target.shortCode &&
+          association.destinationNodeURI.identifier === item.identifier
         ) {
-          targ.DOK = [];
-          targ.DOK.push({
-            dokCode: items.humanCodingScheme,
-            dokDesc: items.fullStatement,
-            dokShort: items.abbreviatedStatement
+          target.DOK = [];
+          target.DOK.push({
+            dokCode: item.humanCodingScheme,
+            dokDesc: item.fullStatement,
+            dokShort: item.abbreviatedStatement
           });
         }
       }
@@ -260,23 +259,21 @@ export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpe
 }
 
 /**
- * This function extracts the target-specific shortcode from one of a documents items
- *
+ * Extracts the target-specific shortcode from one of a document's items
  * @export
  * @param {ISpecDocument} claim
  * @returns {(string | undefined)}
  */
 export function getTargetShortCode(claim: ISpecDocument): string | undefined {
-  for (const p of claim.CFItems) {
-    if (p.CFItemType === 'Target' && p.humanCodingScheme !== undefined) {
-      return p.humanCodingScheme;
+  for (const item of claim.CFItems) {
+    if (item.CFItemType === 'Target' && item.humanCodingScheme !== undefined) {
+      return item.humanCodingScheme;
     }
   }
 }
 
 /**
- * This function extracts the claim shortcode in Subject.Grade.Claim format from a document's title
- *
+ * Extracts the claim shortcode in Subject.Grade.Claim format from a document's title
  * @export
  * @param {string} subject
  * @param {string} claim
@@ -297,8 +294,9 @@ export function getClaimShortCode(subject: string, claim: string, grade: string[
 }
 
 /**
- * This function extracts the claim number from a document's title in CX format (e.g C1, C2, C3)
+ * Extracts the claim number from a document's title in CX format (e.g C1, C2, C3)
  * See Data Structure docs for info on the differences between document titles
+ * (https://github.com/osu-cass/SB-CSE-Data-Structure)
  * @export
  * @param {string} title
  * @param {string} subject
@@ -338,15 +336,14 @@ export function getClaim(title: string, subject: string, grades: string[]) {
 
 /**
  * Fetches all the data for each document supplied from fetchAllDocs()
- *
  * @export
  * @param {ISpecDocument[]} arr
- * @returns
+ * @returns {number}
  */
-export async function importDocs(arr: ISpecDocument[]) {
-  const packages: string[] = await fetchAllDocs();
-  for (const pack of packages) {
-    const data = await fetch(`https://case.smarterbalanced.org/ims/case/v1p0/CFPackages/${pack}`);
+export async function importDocs(arr: ISpecDocument[]): Promise<number> {
+  const identifiers: string[] = await fetchAllDocs();
+  for (const id of identifiers) {
+    const data = await fetch(`https://case.smarterbalanced.org/ims/case/v1p0/CFPackages/${id}`);
     const jsonData: ISpecDocument = await data.json();
     const title: string = jsonData.CFDocument.title;
     const filename: string = title.replace(/[^a-z0-9]/gi, '_').toLowerCase();
@@ -358,36 +355,33 @@ export async function importDocs(arr: ISpecDocument[]) {
     }
   }
 
-  return packages.length;
+  return identifiers.length;
 }
 
 /**
  * Fetches the Identifiers for every document in the CASE DB
- *
  * @export
  * @returns
  */
-export async function fetchAllDocs() {
-  const p: string[] = [];
+export async function fetchAllDocs(): Promise<string[]> {
+  const identifiers: string[] = [];
   const temp = await fetch(
     'https://case.smarterbalanced.org/ims/case/v1p0/CFDocuments?limit=99999999999&offset=0&sort&orderBy&filter&fields'
   );
   const idDoc = await temp.json();
-  // for (let j = 0; j < idDoc.CFDocuments.length; j++) {
-  for (const j of idDoc.CFDocuments) {
-    p.push(j.identifier);
+  for (const document of idDoc.CFDocuments) {
+    identifiers.push(document.identifier);
   }
 
-  return p;
+  return identifiers;
 }
 
 /**
  * Maps Depth-of-knowledge and standards documents
- *
  * @export
- * @returns
+ * @returns {ISpecDocument[]}
  */
-export function specDocs() {
+export function specDocs(): ISpecDocument[] {
   const specs: ISpecDocument[] = [];
   for (let i = 0; i < docNames.length; i++) {
     if (docNames[i].includes('smarter_balanced_ela_content_specification')) {
@@ -404,16 +398,14 @@ export function specDocs() {
   return specs;
 }
 
-// This function extracts target-specific data for a given document
 /**
  *  Extracts target-specific data for a given document
- *
  * @export
  * @param {IClaim} claim
  * @param {ISpecDocument} jsonData
  * @param {ISpecDocument} DOKDOC
  */
-export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecDocument) {
+export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecDocument): void {
   if (claim.shortCode.includes('M.GHS.C') && !claim.shortCode.includes('C1')) {
     getMultiTarget(jsonData, claim, DOKDOC);
   } else {
@@ -451,7 +443,7 @@ export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecD
             evDesc: fullStatement
           });
         }
-        // This block handles a bug in the CASE API where some CFItems are missing their CFItemType property
+        // Special case in the CASE API where some CFItems are missing their CFItemType property
         if (
           p.abbreviatedStatement !== undefined &&
           p.CFItemType === undefined &&
@@ -468,7 +460,6 @@ export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecD
         }
         if (p.CFItemType === 'Task Model' && p.fullStatement.includes('Task Model ')) {
           target.taskModels.push(getTaskModel(p.identifier, jsonData, p.fullStatement));
-          // target.taskModels.push();
         }
         if (p.CFItemType === 'Stem') {
           target.stem.push({
@@ -485,56 +476,54 @@ export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecD
 }
 
 /**
- * builds the Related Evidence for Task Models
- *
+ * Builds the Related Evidence for Task Models
  * @export
  * @param {IClaim} claim
  * @param {ISpecDocument} jsonData
  */
-export function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument) {
+export function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument): void {
   const taskAssociations = jsonData.CFAssociations.filter(
-    assoc =>
-      assoc.originNodeURI.title.includes('Task Model ') &&
-      assoc.destinationNodeURI.title.includes('Evidence Required ')
+    association =>
+      association.originNodeURI.title.includes('Task Model ') &&
+      association.destinationNodeURI.title.includes('Evidence Required ')
   );
 
-  for (const tasks of claim.target[0].taskModels) {
-    tasks.relatedEvidence = [];
-    for (const ta of taskAssociations) {
-      if (ta.originNodeURI.title === tasks.taskName) {
-        tasks.relatedEvidence.push(ta.destinationNodeURI.title);
+  for (const taskModel of claim.target[0].taskModels) {
+    taskModel.relatedEvidence = [];
+    for (const taskAssociation of taskAssociations) {
+      if (taskAssociation.originNodeURI.title === taskModel.taskName) {
+        taskModel.relatedEvidence.push(taskAssociation.destinationNodeURI.title);
       }
     }
   }
 }
 
 /**
- * extracts the target properties that are found under the "General Requirements" itemtypes in a given document
- *
+ * Extracts the target properties that are found under the "General Requirements" item types in a given document
  * @export
  * @param {IClaim} claim
  * @param {ISpecDocument} jsonData
  */
-export function getGenReqs(claim: IClaim, jsonData: ISpecDocument) {
-  for (const p of jsonData.CFItems) {
-    if (p.CFItemType === 'General Requirements') {
-      if (p.abbreviatedStatement === 'Key/Construct Relevant Vocabulary') {
-        claim.target[0].vocab = p.fullStatement;
+export function getGenReqs(claim: IClaim, jsonData: ISpecDocument): void {
+  for (const item of jsonData.CFItems) {
+    if (item.CFItemType === 'General Requirements') {
+      if (item.abbreviatedStatement === 'Key/Construct Relevant Vocabulary') {
+        claim.target[0].vocab = item.fullStatement;
       }
-      if (p.abbreviatedStatement === 'Allowable Tools') {
-        claim.target[0].tools = p.fullStatement;
+      if (item.abbreviatedStatement === 'Allowable Tools') {
+        claim.target[0].tools = item.fullStatement;
       }
-      if (p.abbreviatedStatement === 'Stimuli/Passages') {
-        claim.target[0].stimInfo = p.fullStatement;
+      if (item.abbreviatedStatement === 'Stimuli/Passages') {
+        claim.target[0].stimInfo = item.fullStatement;
       }
-      if (p.abbreviatedStatement === 'Stimuli/Text Complexity') {
-        claim.target[0].complexity = p.fullStatement;
+      if (item.abbreviatedStatement === 'Stimuli/Text Complexity') {
+        claim.target[0].complexity = item.fullStatement;
       }
-      if (p.abbreviatedStatement === 'Development Notes') {
-        claim.target[0].devNotes = p.fullStatement;
+      if (item.abbreviatedStatement === 'Development Notes') {
+        claim.target[0].devNotes = item.fullStatement;
       }
-      if (p.abbreviatedStatement === 'Dual-Text Stimuli') {
-        claim.target[0].dualText = p.fullStatement;
+      if (item.abbreviatedStatement === 'Dual-Text Stimuli') {
+        claim.target[0].dualText = item.fullStatement;
       }
     }
   }
@@ -548,25 +537,21 @@ export function getGenReqs(claim: IClaim, jsonData: ISpecDocument) {
  * @param {ISpecDocument} ELASpec
  * @returns {(string | undefined)}
  */
-function getClaimDomain(
-  subject: string,
-  shortCode: string,
-  ELASpec: ISpecDocument
-): string | undefined {
+function getClaimDomain(shortCode: string, ELASpec: ISpecDocument): string | undefined {
+  let statement: string | undefined;
   for (let i = 0; i < ELASpec.CFItems.length; i++) {
     if (ELASpec.CFItems[i].humanCodingScheme === shortCode) {
       if (ELASpec.CFItems[i + 1].CFItemType === 'Domain') {
-        return ELASpec.CFItems[i + 1].fullStatement;
+        statement = ELASpec.CFItems[i + 1].fullStatement;
       }
     }
   }
 
-  return undefined;
+  return statement;
 }
 
 /**
- * returns the description for a given claim
- *
+ * Finds and returns the description for a given claim
  * @param {string} subject
  * @param {string} shortCode
  * @param {ISpecDocument} ELASpec
@@ -579,7 +564,7 @@ function getClaimDesc(
   ELASpec: ISpecDocument,
   MATHSpec: ISpecDocument
 ): string | undefined {
-  const jsData: ISpecDocument = subject === Subject.ELA ? ELASpec : MATHSpec;
+  const jsonData: ISpecDocument = subject === Subject.ELA ? ELASpec : MATHSpec;
   let code: string | string[] = shortCode;
   let gradeChars;
   if (shortCode.includes('-')) {
@@ -587,16 +572,15 @@ function getClaimDesc(
     code = shortCode.split('.');
     code = `${code[0]}.G${gradeChars}.${code[2]}`;
   }
-  for (const i of jsData.CFItems) {
-    if (i.humanCodingScheme === code) {
-      return i.fullStatement;
+  for (const item of jsonData.CFItems) {
+    if (item.humanCodingScheme === code) {
+      return item.fullStatement;
     }
   }
 }
 
 /**
- *  Consolidates all targets that share the same claim number into a singular claim object with an array of targets.
- *
+ *  Merges all targets that share the same claim number into a singular claim object with an array of targets.
  * @export
  * @param {IClaim[]} claimArray
  * @returns {IClaim[]}
@@ -645,76 +629,78 @@ export function consolidate(claimArray: IClaim[]): IClaim[] {
   expandFirstClaim(finalArray);
 
   // This forEach fixes an error in the CASE API for E.G5.C1.T6 having an incorrect target shortcode
-  finalArray.forEach(c => {
-    if (c.shortCode === 'E.G5.C1a') {
-      c.target[c.target.findIndex(t => t.title.includes('Target 6'))].shortCode = 'E.G5.C1RL.T6';
+  finalArray.forEach(claim => {
+    if (claim.shortCode === 'E.G5.C1a') {
+      claim.target[claim.target.findIndex(target => target.title.includes('Target 6'))].shortCode = 'E.G5.C1RL.T6';
     }
   });
 
-  return finalArray.filter(c => c.claimNumber !== 'C1' || c.subject === Subject.MATH);
+  return finalArray.filter(claim => claim.claimNumber !== 'C1' || claim.subject === Subject.MATH);
 }
 
 /**
- * Handles Splitting C1 into C1a and C1b claims
- *
+ * Special case that splits claim C1 into C1a and C1b claims
  * @export
  * @param {IClaim[]} finalArray
  */
-export function expandFirstClaim(finalArray: IClaim[]) {
-  const tempArr: IClaim[] = [];
+export function expandFirstClaim(finalArray: IClaim[]): void {
+  const claimArray: IClaim[] = [];
   finalArray.forEach(claim => {
     if (claim.claimNumber === 'C1' && claim.subject === Subject.ELA) {
       const temp = JSON.parse(JSON.stringify(claim));
       temp.claimNumber = 'C1a';
       temp.shortCode = temp.shortCode.replace(claim.claimNumber, temp.claimNumber);
       temp.target = [];
-      claim.target.forEach(t => {
-        if (parseInt(t.shortCode.split('.')[3].split('T')[1], 10) <= 7) {
-          temp.target.push(t);
+      claim.target.forEach(target => {
+        if (parseInt(target.shortCode.split('.')[3].split('T')[1], 10) <= 7) {
+          temp.target.push(target);
         }
       });
       claim.shortCode = claim.shortCode.replace(claim.claimNumber, 'C1b');
       claim.claimNumber = 'C1b';
       claim.target = claim.target.filter(
-        t => parseInt(t.shortCode.split('.')[3].split('T')[1], 10) > 7
+        target => parseInt(target.shortCode.split('.')[3].split('T')[1], 10) > 7
       );
-      tempArr.push(temp);
+      claimArray.push(temp);
     }
   });
-  tempArr.forEach(c => finalArray.push(c));
+  claimArray.forEach(c => finalArray.push(c));
 }
 
 /**
- * Merges Performance Task Targets into their corresponding grade-and-claims
- *
+ * Merges Targets of the type 'Performance Task' into their corresponding grade-and-claims
  * @export
  * @param {IClaim[]} finalArray
  */
-export function handlePT(finalArray: IClaim[]) {
+export function handlePT(finalArray: IClaim[]): void {
   let PTArr: IClaim[] = [];
-  let tempIdx;
+  let idx: number;
 
   PTArr = finalArray.filter(claim => claim.title.includes('Performance'));
   PTArr.forEach(PT => {
-    for (const targ of PT.target) {
+    for (const target of PT.target) {
       if (parseInt(PT.grades[0], 10) < 8) {
-        tempIdx = finalArray.findIndex(claim => {
-          return claim.shortCode === targ.shortCode.slice(0, 7);
+        idx = finalArray.findIndex(claim => {
+          return claim.shortCode === target.shortCode.slice(0, 7);
         });
-        finalArray[tempIdx].target.push(targ);
+        finalArray[idx].target.push(target);
       }
     }
   });
 }
 
-export function removePT(finalArray: IClaim[]) {
+/**
+ * Excludes 'Performance Task' claims from IClaim[]
+ * @param finalArray
+ * @returns {IClaim[]}
+ */
+export function removePT(finalArray: IClaim[]): IClaim[] {
   return finalArray.filter(claim => !claim.title.includes('Performance'));
 }
 
 // tslint:disable:no-non-null-assertion
 /**
- * Handles building task models with Item Associations
- *
+ * Builds task models from Item Associations
  * @export
  * @param {string} identifier
  * @param {ISpecDocument} jsonData
@@ -727,30 +713,38 @@ export function getTaskModel(
   name: string
 ): ITaskModel {
   const associations = jsonData.CFAssociations.filter(
-    a => a.destinationNodeURI.identifier === identifier
+    association => association.destinationNodeURI.identifier === identifier
   );
-  const descId = associations.find(a => a.originNodeURI.title === 'Task Description')!.originNodeURI
-    .identifier;
-  const stimId = associations.find(a => a.originNodeURI.title === 'Stimulus')
-    ? associations.find(a => a.originNodeURI.title === 'Stimulus')!.originNodeURI.identifier
+
+  const descriptionId = associations.find(
+    association => association.originNodeURI.title === 'Task Description'
+  )!.originNodeURI.identifier;
+
+  const stimulusId = associations.find(
+    association => association.originNodeURI.title === 'Stimulus'
+  )
+    ? associations.find(association => association.originNodeURI.title === 'Stimulus')!
+        .originNodeURI.identifier
     : undefined;
-  const stemId = associations.find(a => a.originNodeURI.title === 'Appropriate Stems')
-    ? associations.find(a => a.originNodeURI.title === 'Appropriate Stems')!.originNodeURI
-        .identifier
-    : undefined;
-  const stemInfo = stemId
-    ? {
-        stemDesc: jsonData.CFItems.find(c => c.identifier === stemId)!.fullStatement,
-        shortStem: jsonData.CFItems.find(c => c.identifier === stemId)!.abbreviatedStatement
-      }
+
+  const stemId = associations.find(
+    association => association.originNodeURI.title === 'Appropriate Stems'
+  )
+    ? associations.find(association => association.originNodeURI.title === 'Appropriate Stems')!
+        .originNodeURI.identifier
     : undefined;
 
   return {
     taskName: name,
-    taskDesc: jsonData.CFItems.find(c => c.identifier === descId)!.fullStatement,
-    stimulus: stimId
-      ? jsonData.CFItems.find(c => c.identifier === stimId)!.fullStatement
+    taskDesc: jsonData.CFItems.find(c => c.identifier === descriptionId)!.fullStatement,
+    stimulus: stimulusId
+      ? jsonData.CFItems.find(c => c.identifier === stimulusId)!.fullStatement
       : undefined,
-    stem: stemInfo
+    stem: stemId
+      ? {
+          stemDesc: jsonData.CFItems.find(c => c.identifier === stemId)!.fullStatement,
+          shortStem: jsonData.CFItems.find(c => c.identifier === stemId)!.abbreviatedStatement
+        }
+      : undefined
   };
 }

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -705,11 +705,7 @@ function getClaimDesc(
   const stemId = getAssocId(associations, 'Appropriate Stems', true);
   const exampleArr = associations.filter(association => association.originNodeURI.title === 'Examples');
   const exampleText: string[] | undefined = [];
-  exampleArr.forEach(e => {
-    if (findAssocItem(jsonData, e.originNodeURI.identifier, false)) {
-      exampleText.push(findAssocItem(jsonData, e.originNodeURI.identifier, false));
-    }
-  });
+  getExamples(exampleArr, jsonData, exampleText);
 
   return {
     taskName: name,
@@ -726,6 +722,18 @@ function getClaimDesc(
       : undefined
   };
 }
+function getExamples(exampleArr: ICFAssociation[], jsonData: ISpecDocument, exampleText: string[]) {
+  exampleArr.forEach(e => {
+    if (findAssocItem(jsonData, e.originNodeURI.identifier, false) !== 'Examples') {
+      exampleText.push(findAssocItem(jsonData, e.originNodeURI.identifier, false));
+    }
+    else {
+      const exampleChildren = jsonData.CFAssociations.filter(a => a.destinationNodeURI.title === 'Examples' && a.originNodeURI.title.includes('Example '));
+      exampleChildren.forEach(e => exampleText.push(findAssocItem(jsonData, e.originNodeURI.identifier, false)));
+    }
+  });
+}
+
 /**
  * This function returns the item GUID for a queried association in the document
  *

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -736,14 +736,14 @@ export function getTaskModel(
 
   return {
     taskName: name,
-    taskDesc: jsonData.CFItems.find(c => c.identifier === descriptionId)!.fullStatement,
+    taskDesc: jsonData.CFItems.find(item => item.identifier === descriptionId)!.fullStatement,
     stimulus: stimulusId
-      ? jsonData.CFItems.find(c => c.identifier === stimulusId)!.fullStatement
+      ? jsonData.CFItems.find(item => item.identifier === stimulusId)!.fullStatement
       : undefined,
     stem: stemId
       ? {
-          stemDesc: jsonData.CFItems.find(c => c.identifier === stemId)!.fullStatement,
-          shortStem: jsonData.CFItems.find(c => c.identifier === stemId)!.abbreviatedStatement
+          stemDesc: jsonData.CFItems.find(item => item.identifier === stemId)!.fullStatement,
+          shortStem: jsonData.CFItems.find(item => item.identifier === stemId)!.abbreviatedStatement
         }
       : undefined
   };

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -27,7 +27,12 @@ const docs = [
 const docArr: ISpecDocument[] = [];
 const docNames: string[] = [];
 // tslint:disable:max-func-body-length
-// This function migrates CASE API documents into a new data model.
+/**
+ * This function migrates CASE API documents into a new data model.
+ *
+ * @export
+ * @returns {Promise<IClaim[]>}
+ */
 export async function importDbEntries(): Promise<IClaim[]> {
   let dokSpec: ISpecDocument;
   let newClaim: any = {};
@@ -141,6 +146,15 @@ export async function importDbEntries(): Promise<IClaim[]> {
 
   return consolidate(claimArray);
 }
+
+/**
+ * Handles merging split multi-targets into the main claim array
+ *
+ * @export
+ * @param {IClaim[]} claimArray
+ * @param {IClaim} newClaim
+ * @param {ISpecDocument} claim
+ */
 export function pushToClaimArray(claimArray: IClaim[], newClaim: IClaim, claim: ISpecDocument) {
   let temp: IClaim;
   if (newClaim.target[0].title.includes('Targets ')) {
@@ -157,7 +171,15 @@ export function pushToClaimArray(claimArray: IClaim[], newClaim: IClaim, claim: 
   }
   claimArray.push(newClaim);
 }
-// This function handles target information for multi-grade-and-claim documents
+
+/**
+ * This function handles target information for multi-grade-and-claim documents
+ *
+ * @export
+ * @param {ISpecDocument} claim
+ * @param {*} newClaim
+ * @param {ISpecDocument} DOKDOC
+ */
 export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpecDocument) {
   const tModels: ITaskModel[] = [];
   const titleArr: string[] = [];
@@ -237,7 +259,13 @@ export function getMultiTarget(claim: ISpecDocument, newClaim: any, DOKDOC: ISpe
   newClaim.target.shift();
 }
 
-// This function extracts the target-specific shortcode from one of a documents items
+/**
+ * This function extracts the target-specific shortcode from one of a documents items
+ *
+ * @export
+ * @param {ISpecDocument} claim
+ * @returns {(string | undefined)}
+ */
 export function getTargetShortCode(claim: ISpecDocument): string | undefined {
   for (const p of claim.CFItems) {
     if (p.CFItemType === 'Target' && p.humanCodingScheme !== undefined) {
@@ -245,7 +273,16 @@ export function getTargetShortCode(claim: ISpecDocument): string | undefined {
     }
   }
 }
-// This function extracts the claim shortcode in Subject.Grade.Claim format from a document's title
+
+/**
+ * This function extracts the claim shortcode in Subject.Grade.Claim format from a document's title
+ *
+ * @export
+ * @param {string} subject
+ * @param {string} claim
+ * @param {string[]} grade
+ * @returns
+ */
 export function getClaimShortCode(subject: string, claim: string, grade: string[]) {
   const gradeLevel: string | string[] = parseInt(grade[0], 10) > 8 ? 'HS' : grade;
   if (grade.length > 1) {
@@ -259,8 +296,15 @@ export function getClaimShortCode(subject: string, claim: string, grade: string[
   return subject === Subject.ELA ? `E.G${gradeLevel}.${claim}` : `M.G${gradeLevel}.${claim}`;
 }
 
-// This function extracts the claim number from a document's title in CX format (e.g C1, C2, C3)
-// See Data Structure docs for info on the differences between document titles
+/**
+ * This function extracts the claim number from a document's title in CX format (e.g C1, C2, C3)
+ * See Data Structure docs for info on the differences between document titles
+ * @export
+ * @param {string} title
+ * @param {string} subject
+ * @param {string[]} grades
+ * @returns
+ */
 export function getClaim(title: string, subject: string, grades: string[]) {
   let titlecopy = ` ${title}`.slice(1);
   let titlearray = [];
@@ -292,6 +336,13 @@ export function getClaim(title: string, subject: string, grades: string[]) {
   return `C${titlearray[4]}`;
 }
 
+/**
+ * Fetches all the data for each document supplied from fetchAllDocs()
+ *
+ * @export
+ * @param {ISpecDocument[]} arr
+ * @returns
+ */
 export async function importDocs(arr: ISpecDocument[]) {
   const packages: string[] = await fetchAllDocs();
   for (const pack of packages) {
@@ -310,6 +361,12 @@ export async function importDocs(arr: ISpecDocument[]) {
   return packages.length;
 }
 
+/**
+ * Fetches the Identifiers for every document in the CASE DB
+ *
+ * @export
+ * @returns
+ */
 export async function fetchAllDocs() {
   const p: string[] = [];
   const temp = await fetch(
@@ -324,6 +381,12 @@ export async function fetchAllDocs() {
   return p;
 }
 
+/**
+ * Maps Depth-of-knowledge and standards documents
+ *
+ * @export
+ * @returns
+ */
 export function specDocs() {
   const specs: ISpecDocument[] = [];
   for (let i = 0; i < docNames.length; i++) {
@@ -340,7 +403,16 @@ export function specDocs() {
 
   return specs;
 }
+
 // This function extracts target-specific data for a given document
+/**
+ *  Extracts target-specific data for a given document
+ *
+ * @export
+ * @param {IClaim} claim
+ * @param {ISpecDocument} jsonData
+ * @param {ISpecDocument} DOKDOC
+ */
 export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecDocument) {
   if (claim.shortCode.includes('M.GHS.C') && !claim.shortCode.includes('C1')) {
     getMultiTarget(jsonData, claim, DOKDOC);
@@ -394,9 +466,7 @@ export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecD
         if (p.CFItemType === 'Accessibility') {
           target.accessibility = fullStatement;
         }
-        if (
-          p.CFItemType === 'Task Model' && p.fullStatement.includes('Task Model ')
-        ) {
+        if (p.CFItemType === 'Task Model' && p.fullStatement.includes('Task Model ')) {
           target.taskModels.push(getTaskModel(p.identifier, jsonData, p.fullStatement));
           // target.taskModels.push();
         }
@@ -414,6 +484,13 @@ export function getTarget(claim: IClaim, jsonData: ISpecDocument, DOKDOC: ISpecD
   getGenReqs(claim, jsonData);
 }
 
+/**
+ * builds the Related Evidence for Task Models
+ *
+ * @export
+ * @param {IClaim} claim
+ * @param {ISpecDocument} jsonData
+ */
 export function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument) {
   const taskAssociations = jsonData.CFAssociations.filter(
     assoc =>
@@ -431,7 +508,13 @@ export function getAssociatedEvidence(claim: IClaim, jsonData: ISpecDocument) {
   }
 }
 
-// This function extracts the target properties that are found under the "General Requirements" itemtypes in a given document
+/**
+ * extracts the target properties that are found under the "General Requirements" itemtypes in a given document
+ *
+ * @export
+ * @param {IClaim} claim
+ * @param {ISpecDocument} jsonData
+ */
 export function getGenReqs(claim: IClaim, jsonData: ISpecDocument) {
   for (const p of jsonData.CFItems) {
     if (p.CFItemType === 'General Requirements') {
@@ -456,7 +539,15 @@ export function getGenReqs(claim: IClaim, jsonData: ISpecDocument) {
     }
   }
 }
-// This function returns the domain for a given ELA document.
+
+/**
+ * returns the domain for a given ELA document.
+ *
+ * @param {string} subject
+ * @param {string} shortCode
+ * @param {ISpecDocument} ELASpec
+ * @returns {(string | undefined)}
+ */
 function getClaimDomain(
   subject: string,
   shortCode: string,
@@ -472,7 +563,16 @@ function getClaimDomain(
 
   return undefined;
 }
-// This function returns the description for a given claim
+
+/**
+ * returns the description for a given claim
+ *
+ * @param {string} subject
+ * @param {string} shortCode
+ * @param {ISpecDocument} ELASpec
+ * @param {ISpecDocument} MATHSpec
+ * @returns {(String || undefined)}
+ */
 function getClaimDesc(
   subject: string,
   shortCode: string,
@@ -493,7 +593,14 @@ function getClaimDesc(
     }
   }
 }
-// This function consolidates all targets that share the same claim number into a singular claim object with an array of targets.
+
+/**
+ *  Consolidates all targets that share the same claim number into a singular claim object with an array of targets.
+ *
+ * @export
+ * @param {IClaim[]} claimArray
+ * @returns {IClaim[]}
+ */
 export function consolidate(claimArray: IClaim[]): IClaim[] {
   let tempArray = [];
   let claimHolder;
@@ -547,6 +654,12 @@ export function consolidate(claimArray: IClaim[]): IClaim[] {
   return finalArray.filter(c => c.claimNumber !== 'C1' || c.subject === Subject.MATH);
 }
 
+/**
+ * Handles Splitting C1 into C1a and C1b claims
+ *
+ * @export
+ * @param {IClaim[]} finalArray
+ */
 export function expandFirstClaim(finalArray: IClaim[]) {
   const tempArr: IClaim[] = [];
   finalArray.forEach(claim => {
@@ -570,6 +683,13 @@ export function expandFirstClaim(finalArray: IClaim[]) {
   });
   tempArr.forEach(c => finalArray.push(c));
 }
+
+/**
+ * Merges Performance Task Targets into their corresponding grade-and-claims
+ *
+ * @export
+ * @param {IClaim[]} finalArray
+ */
 export function handlePT(finalArray: IClaim[]) {
   let PTArr: IClaim[] = [];
   let tempIdx;
@@ -590,21 +710,47 @@ export function handlePT(finalArray: IClaim[]) {
 export function removePT(finalArray: IClaim[]) {
   return finalArray.filter(claim => !claim.title.includes('Performance'));
 }
-// tslint:disable:no-non-null-assertion
-export function getTaskModel(identifier: string, jsonData: ISpecDocument, name: string) {
-  const associations = jsonData.CFAssociations.filter(a => a.destinationNodeURI.identifier === identifier);
-  const descId = associations.find(a => a.originNodeURI.title === 'Task Description')!.originNodeURI.identifier;
-  const stimId = associations.find(a => a.originNodeURI.title === 'Stimulus') ? associations.find(a => a.originNodeURI.title === 'Stimulus')!.originNodeURI.identifier : undefined;
-  const stemId = associations.find(a => a.originNodeURI.title === 'Appropriate Stems')? associations.find(a => a.originNodeURI.title === 'Appropriate Stems')!.originNodeURI.identifier : undefined;
- const stemInfo = stemId ? {
-    stemDesc: jsonData.CFItems.find(c => c.identifier === stemId)!.fullStatement,
-    shortStem: jsonData.CFItems.find(c => c.identifier === stemId)!.abbreviatedStatement,
-  } : undefined;
 
-  return  {
+// tslint:disable:no-non-null-assertion
+/**
+ * Handles building task models with Item Associations
+ *
+ * @export
+ * @param {string} identifier
+ * @param {ISpecDocument} jsonData
+ * @param {string} name
+ * @returns {ITaskModel}
+ */
+export function getTaskModel(
+  identifier: string,
+  jsonData: ISpecDocument,
+  name: string
+): ITaskModel {
+  const associations = jsonData.CFAssociations.filter(
+    a => a.destinationNodeURI.identifier === identifier
+  );
+  const descId = associations.find(a => a.originNodeURI.title === 'Task Description')!.originNodeURI
+    .identifier;
+  const stimId = associations.find(a => a.originNodeURI.title === 'Stimulus')
+    ? associations.find(a => a.originNodeURI.title === 'Stimulus')!.originNodeURI.identifier
+    : undefined;
+  const stemId = associations.find(a => a.originNodeURI.title === 'Appropriate Stems')
+    ? associations.find(a => a.originNodeURI.title === 'Appropriate Stems')!.originNodeURI
+        .identifier
+    : undefined;
+  const stemInfo = stemId
+    ? {
+        stemDesc: jsonData.CFItems.find(c => c.identifier === stemId)!.fullStatement,
+        shortStem: jsonData.CFItems.find(c => c.identifier === stemId)!.abbreviatedStatement
+      }
+    : undefined;
+
+  return {
     taskName: name,
     taskDesc: jsonData.CFItems.find(c => c.identifier === descId)!.fullStatement,
-    stimulus: stimId ? jsonData.CFItems.find(c => c.identifier === stimId)!.fullStatement : undefined,
-    stem : stemInfo
+    stimulus: stimId
+      ? jsonData.CFItems.find(c => c.identifier === stimId)!.fullStatement
+      : undefined,
+    stem: stemInfo
   };
 }

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -734,12 +734,26 @@ export function getTaskModel(
         .originNodeURI.identifier
     : undefined;
 
+    const exampleArr = associations.filter(association => association.originNodeURI.title === 'Examples');
+    let exampleText: string[] | undefined = [];
+    if(exampleArr.length > 0) {
+    exampleArr.forEach(e =>  {
+      if(jsonData.CFItems.find(item => item.identifier === e.originNodeURI.identifier)) {
+        exampleText!.push(jsonData.CFItems.find(item => item.identifier === e.originNodeURI.identifier)!.fullStatement);
+      }
+    });
+    }
+    else {
+      exampleText = undefined;
+    }
+
   return {
     taskName: name,
     taskDesc: jsonData.CFItems.find(item => item.identifier === descriptionId)!.fullStatement,
     stimulus: stimulusId
       ? jsonData.CFItems.find(item => item.identifier === stimulusId)!.fullStatement
       : undefined,
+      examples: exampleText,
     stem: stemId
       ? {
           stemDesc: jsonData.CFItems.find(item => item.identifier === stemId)!.fullStatement,

--- a/src/dal/search/index.ts
+++ b/src/dal/search/index.ts
@@ -62,9 +62,8 @@ export class SearchClient implements ISearchClient {
 
     if (grades) {
       body.size(100).query('bool', {
-          should: grades.split(',').map((grade: string) => ({ match: { grades: grade } }))
-        }
-      );
+        should: grades.split(',').map((grade: string) => ({ match: { grades: grade } }))
+      });
     }
 
     if (claimNumber) {

--- a/src/dal/search/search.spec.ts
+++ b/src/dal/search/search.spec.ts
@@ -197,7 +197,7 @@ describe('search', () => {
             ]
           }
         },
-        size: 100,
+        size: 100
       };
     });
 
@@ -296,7 +296,7 @@ describe('search', () => {
             ]
           }
         },
-        size: 100,
+        size: 100
       });
     });
   });

--- a/src/models/target/index.ts
+++ b/src/models/target/index.ts
@@ -4,6 +4,7 @@ export interface ITaskModel {
   examples?: string[];
   stimulus?: string;
   relatedEvidence?: string[];
+  stem?: IStem;
 }
 
 export interface IStem {


### PR DESCRIPTION
# Changes introduced
Importing task models now uses Cf Associations as logic
## Related issue(s):
CSE-390
## Contributor checklist

- [ ] Wrote/updated tests for introduced changes
- [ ] ~~Added new stories for created/modified components (if applicable)~~
- [ ] Updated Postman library for created/modified routes (if applicable)
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] ~~Verified that stories were written/modified (if applicable)~~
- [ ] Verified that Postman was updated (if applicable)
- [ ] Checked out the branch and tested changes locally
