### PR TITLE
feat(data-structure): adds support for pt general info field

### DIFF
--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -418,7 +418,7 @@ export async function importDocs(arr: ISpecDocument[]): Promise<number> {
             stdDesc: fullStatement
           });
         }
-        if (p.CFItemType === 'Target' && p.abbreviatedStatement === target.shortCode) {
+        if (p.CFItemType === 'Target') {
           target.description = fullStatement;
         }
         if (p.CFItemType === 'Clarification') {
@@ -474,6 +474,8 @@ export async function importDocs(arr: ISpecDocument[]): Promise<number> {
  * @param {ISpecDocument} jsonData
  */
 function getPTGeneralInfo(claim: IClaim, jsonData: ISpecDocument) {
+  const desc = jsonData.CFItems.find(i => i.CFItemType === 'Target' && i.abbreviatedStatement === claim.target[0].shortCode);
+  claim.target[0].description = desc ? desc.fullStatement : claim.target[0].description;
   if(claim.target[0].interactionType === 'PT') {
     const performanceInfoItem = jsonData.CFItems.find(item => item.abbreviatedStatement === 'Performance Task (General Information)');
     if(performanceInfoItem) {

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -418,7 +418,7 @@ export async function importDocs(arr: ISpecDocument[]): Promise<number> {
             stdDesc: fullStatement
           });
         }
-        if (p.CFItemType === 'Target' && p !== jsonData.CFItems[jsonData.CFItems.length - 1]) {
+        if (p.CFItemType === 'Target' && p.abbreviatedStatement === target.shortCode) {
           target.description = fullStatement;
         }
         if (p.CFItemType === 'Clarification') {
@@ -462,8 +462,22 @@ export async function importDocs(arr: ISpecDocument[]): Promise<number> {
       }
     }
   }
+  getPTGeneralInfo(claim, jsonData);
   getAssociatedEvidence(claim, jsonData);
   getGenReqs(claim, jsonData);
+}
+
+/**
+ * Finds and sets the special case target descriptions for a Performance Task document
+ *
+ * @param {IClaim} claim
+ * @param {ISpecDocument} jsonData
+ */
+function getPTGeneralInfo(claim: IClaim, jsonData: ISpecDocument) {
+  if(claim.target[0].interactionType === 'PT') {
+    const info = jsonData.CFItems.find(item => item.abbreviatedStatement === 'Performance Task (General Information)');
+    claim.target[0].performanceInfo = info ? info.fullStatement : undefined;
+  }
 }
 
 /**

--- a/src/dal/import/index.ts
+++ b/src/dal/import/index.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import { ISpecDocument, ICFAssociation } from './interfaces';
 import { IClaim, ClaimExpansion } from '../../models/claim';
-import { IDOK, ITaskModel } from '../../models/target';
+import { IDOK, ITaskModel, IPerformanceInfo } from '../../models/target';
 
 // This is required for translating specDocuments to an IClaim type
 // tslint:disable:no-unsafe-any no-any
@@ -468,15 +468,18 @@ export async function importDocs(arr: ISpecDocument[]): Promise<number> {
 }
 
 /**
- * Finds and sets the special case target descriptions for a Performance Task document
+ * Finds and sets the special case General Information for a Performance Task document
  *
  * @param {IClaim} claim
  * @param {ISpecDocument} jsonData
  */
 function getPTGeneralInfo(claim: IClaim, jsonData: ISpecDocument) {
   if(claim.target[0].interactionType === 'PT') {
-    const info = jsonData.CFItems.find(item => item.abbreviatedStatement === 'Performance Task (General Information)');
-    claim.target[0].performanceInfo = info ? info.fullStatement : undefined;
+    const performanceInfoItem = jsonData.CFItems.find(item => item.abbreviatedStatement === 'Performance Task (General Information)');
+    if(performanceInfoItem) {
+      const info: IPerformanceInfo = {title: 'Performance Task (General Information)', description: performanceInfoItem.fullStatement};
+      claim.target[0].taskModels.push(info);
+    }
   }
 }
 
@@ -492,7 +495,7 @@ function getPTGeneralInfo(claim: IClaim, jsonData: ISpecDocument) {
       association.destinationNodeURI.title.includes('Evidence Required ')
   );
 
-  for (const taskModel of claim.target[0].taskModels) {
+  for (const taskModel of claim.target[0].taskModels as ITaskModel[]) {
     taskModel.relatedEvidence = [];
     for (const taskAssociation of taskAssociations) {
       if (taskAssociation.originNodeURI.title === taskModel.taskName) {

--- a/src/models/target/index.ts
+++ b/src/models/target/index.ts
@@ -34,6 +34,7 @@ export interface ITarget {
   standards: IStandards[];
   DOK: IDOK[];
   interactionType: string;
+  performanceInfo?: string;
   clarification: string;
   heading: string;
   evidence: IEvidence[];

--- a/src/models/target/index.ts
+++ b/src/models/target/index.ts
@@ -34,7 +34,6 @@ export interface ITarget {
   standards: IStandards[];
   DOK: IDOK[];
   interactionType: string;
-  performanceInfo?: string;
   clarification: string;
   heading: string;
   evidence: IEvidence[];
@@ -46,6 +45,11 @@ export interface ITarget {
   dualText: string;
   accessibility: string;
   stem: IStem[];
-  taskModels: ITaskModel[];
+  taskModels: (ITaskModel | IPerformanceInfo)[];
   rubrics: string[];
+}
+
+export interface IPerformanceInfo {
+  title: string;
+  description: string;
 }


### PR DESCRIPTION
# Changes introduced
Updates Data Structure to include Performance Task (General Information Field)
This change will need to be reflected in the front-end model as this will temporarily break PT Targets on the front end.
## Related issue(s):

- CSE-436


## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] ~~Added new stories for created/modified components (if applicable)~~
- [ ] Updated Postman library for created/modified routes (if applicable)
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] ~~Verified that stories were written/modified (if applicable)~~
- [ ] Verified that Postman was updated (if applicable)
- [ ] Checked out the branch and tested changes locally
